### PR TITLE
fix reference to venv instead of base-interpreter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ install(TARGETS myactuator_rmd
 )
 
 if(PYTHON_BINDINGS)
-  find_package(Python REQUIRED COMPONENTS
+  find_package(Python3 REQUIRED COMPONENTS
     Development  
     Interpreter
   )

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ class CMakeBuild(build_ext):
 
         cmake_args = [
             f"-D CMAKE_LIBRARY_OUTPUT_DIRECTORY={extdir}{os.sep}",
-            f"-D PYTHON_EXECUTABLE={sys.executable}",
+            f"-D Python3_EXECUTABLE={sys.executable}",
             f"-D CMAKE_BUILD_TYPE={cfg}",
             f"-D PYTHON_BINDINGS=on"
         ]


### PR DESCRIPTION
I would like to install this nice library in my `Python3.13` venv as created by `uv` on ArchLinux KDE Plasma with the following dependencies and initialization script:

**dependencies:**
```
cmake: 3.31.5

venv (created by uv):
    "pip==25.0",
    "pybind11==2.13.6",
    "setuptools==75.8.0",
```

**script:**
```
#!/usr/bin/zsh
cd ./../myactuator_rmd

# set location to venv where python3 is installed
export PYTHON313_PATH=./../../.venv/bin

# set Python and pip
export PYTHON3=$PYTHON313_PATH/python
export PIP=$PYTHON313_PATH/pip

# add venv to path and find pybind11 path
export PATH=$PYTHON313_PATH:$PATH
export pybind11_DIR=$($PYTHON3 -c "import pybind11; print(pybind11.get_cmake_dir())")

# remove build-folder to force a clean build
if [[ -d "./build" ]]; then
  rm -rf "./build"
  echo "./build deleted."
else
  echo "Folder does not exist."
fi

echo "> Installing 'myactuator_rmd_py'"
$PIP install . -v
echo "> 'myactuator_rmd_py' has been installed successfully"
```

However in the log I found a reference to another python version (3.12 instead of the venv).

> -- Detecting CXX compile features
  -- Detecting CXX compile features - done
  **-- Found Python: /usr/local/bin/python3.12 (found version "3.12.8") found components: Development Interpreter Development.Module Development.Embed**
  -- Performing Test HAS_FLTO
  -- Performing Test HAS_FLTO - Success
  -- Found pybind11: ~/project/.venv/lib/python3.13/site-packages/pybind11/include (found version "2.13.6")

This PR suggests to change the references to `Python3_EXECUTABLE` and `Python3` resulting in the correct reference to the expected venv:

> -- Detecting CXX compile features
  -- Detecting CXX compile features - done
  **-- Found Python: ~/project/.venv/bin/python3.13 (found version "3.13.1") found components: Development Interpreter Development.Module Development.Embed**
  -- Performing Test HAS_FLTO
  -- Performing Test HAS_FLTO - Success
  -- Found pybind11: ~/project/.venv/lib/python3.13/site-packages/pybind11/include (found version "2.13.6")


